### PR TITLE
Fixed CMakeLists: Added 2 missing packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Eigen3 3.3 REQUIRED)
+find_package(GTest REQUIRED)
+find_package(absl CONFIG REQUIRED)
 find_package(Ceres REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(yaml-cpp REQUIRED)


### PR DESCRIPTION
The cmake command in the docker container gives an error message, because the 2 packages are missing.
This resolves the error. 